### PR TITLE
fixed unicode error for ruby versions >= 1.9.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "bundler"
 Bundler.setup
-$KCODE = 'U'
+$KCODE = 'U' if RUBY_VERSION < '1.9.0'
 
 require 'rake/testtask'
 

--- a/lib/drivenow.rb
+++ b/lib/drivenow.rb
@@ -1,3 +1,3 @@
-$KCODE = 'U'
+$KCODE = 'U' if RUBY_VERSION < '1.9.0'
 require 'drivenow/drivenow_car'
 require 'drivenow/drivenow_agent'

--- a/lib/drivenow/drivenow_agent.rb
+++ b/lib/drivenow/drivenow_agent.rb
@@ -2,7 +2,7 @@ module Drivenow
 	class Agent
 		require 'open-uri'
 		require 'json'
-		$KCODE = "U"
+		$KCODE = "U" if RUBY_VERSION < '1.9.0'
 
 		attr_reader :cars
 


### PR DESCRIPTION
When trying to install the gem I get the following error message: 

``` ruby
Installing ri documentation for drivenow-1.0.1...
unable to convert "\xC3" from ASCII-8BIT to UTF-8 for lib/drivenow/drivenow_agent.rb, skipping
Installing RDoc documentation for drivenow-1.0.1...
unable to convert "\xC3" from ASCII-8BIT to UTF-8 for lib/drivenow/drivenow_agent.rb, skipping

```
